### PR TITLE
feat: タイトル画面からテキストシーンへの遷移機能実装 (#23)

### DIFF
--- a/GodotProject/Scenes/TextScene.tscn
+++ b/GodotProject/Scenes/TextScene.tscn
@@ -1,0 +1,193 @@
+[gd_scene load_steps=3 format=3 uid="uid://c5mq8yf0lg8r5"]
+
+[ext_resource type="Script" path="res://Scripts/ui/text_scene.gd" id="1_h3q8m"]
+
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_1"]
+bg_color = Color(0.1, 0.1, 0.1, 0.8)
+border_width_left = 2
+border_width_top = 2
+border_width_right = 2
+border_width_bottom = 2
+border_color = Color(0.7, 0.7, 0.7, 1)
+corner_radius_top_left = 8
+corner_radius_top_right = 8
+corner_radius_bottom_right = 8
+corner_radius_bottom_left = 8
+
+[node name="TextScene" type="Control"]
+layout_mode = 3
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+script = ExtResource("1_h3q8m")
+
+[node name="BackgroundLayer" type="Control" parent="."]
+layout_mode = 1
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+mouse_filter = 2
+
+[node name="Background" type="TextureRect" parent="BackgroundLayer"]
+layout_mode = 1
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+mouse_filter = 2
+stretch_mode = 5
+
+[node name="CharacterLayer" type="Control" parent="."]
+layout_mode = 1
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+mouse_filter = 2
+
+[node name="CharacterLeft" type="TextureRect" parent="CharacterLayer"]
+layout_mode = 1
+anchors_preset = 4
+anchor_top = 0.5
+anchor_bottom = 0.5
+offset_left = 50.0
+offset_top = -300.0
+offset_right = 350.0
+offset_bottom = 300.0
+mouse_filter = 2
+stretch_mode = 4
+
+[node name="CharacterRight" type="TextureRect" parent="CharacterLayer"]
+layout_mode = 1
+anchors_preset = 6
+anchor_left = 1.0
+anchor_top = 0.5
+anchor_right = 1.0
+anchor_bottom = 0.5
+offset_left = -350.0
+offset_top = -300.0
+offset_right = -50.0
+offset_bottom = 300.0
+mouse_filter = 2
+stretch_mode = 4
+
+[node name="UILayer" type="Control" parent="."]
+layout_mode = 1
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+
+[node name="TextWindow" type="Panel" parent="UILayer"]
+layout_mode = 1
+anchors_preset = 2
+anchor_top = 1.0
+anchor_bottom = 1.0
+offset_left = 50.0
+offset_top = -200.0
+offset_right = -50.0
+offset_bottom = -50.0
+theme_override_styles/panel = SubResource("StyleBoxFlat_1")
+
+[node name="NameContainer" type="HBoxContainer" parent="UILayer/TextWindow"]
+layout_mode = 1
+anchors_preset = 10
+anchor_right = 1.0
+offset_left = 20.0
+offset_top = 10.0
+offset_right = -20.0
+offset_bottom = 40.0
+
+[node name="NameLabel" type="Label" parent="UILayer/TextWindow/NameContainer"]
+layout_mode = 2
+theme_override_colors/font_color = Color(1, 1, 0.8, 1)
+theme_override_font_sizes/font_size = 18
+text = "キャラクター名"
+vertical_alignment = 1
+
+[node name="TextContainer" type="MarginContainer" parent="UILayer/TextWindow"]
+layout_mode = 1
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+offset_left = 20.0
+offset_top = 50.0
+offset_right = -20.0
+offset_bottom = -40.0
+
+[node name="TextLabel" type="RichTextLabel" parent="UILayer/TextWindow/TextContainer"]
+layout_mode = 2
+theme_override_colors/default_color = Color(1, 1, 1, 1)
+theme_override_font_sizes/normal_font_size = 16
+bbcode_enabled = true
+text = "ここにテキストが表示されます。"
+fit_content = true
+scroll_active = false
+
+[node name="ContinueIndicator" type="Label" parent="UILayer/TextWindow"]
+layout_mode = 1
+anchors_preset = 3
+anchor_left = 1.0
+anchor_top = 1.0
+anchor_right = 1.0
+anchor_bottom = 1.0
+offset_left = -80.0
+offset_top = -30.0
+offset_right = -20.0
+offset_bottom = -10.0
+theme_override_colors/font_color = Color(1, 1, 0.8, 1)
+theme_override_font_sizes/font_size = 14
+text = "▼クリック"
+horizontal_alignment = 2
+vertical_alignment = 1
+
+[node name="LogButton" type="Button" parent="UILayer"]
+layout_mode = 1
+anchors_preset = 1
+anchor_left = 1.0
+anchor_right = 1.0
+offset_left = -120.0
+offset_top = 20.0
+offset_right = -20.0
+offset_bottom = 60.0
+text = "ログ"
+
+[node name="LogPanel" type="Panel" parent="UILayer"]
+visible = false
+layout_mode = 1
+anchors_preset = 8
+anchor_left = 0.5
+anchor_top = 0.5
+anchor_right = 0.5
+anchor_bottom = 0.5
+offset_left = -300.0
+offset_top = -200.0
+offset_right = 300.0
+offset_bottom = 200.0
+theme_override_styles/panel = SubResource("StyleBoxFlat_1")
+
+[node name="LogContainer" type="VBoxContainer" parent="UILayer/LogPanel"]
+layout_mode = 1
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+offset_left = 20.0
+offset_top = 20.0
+offset_right = -20.0
+offset_bottom = -20.0
+
+[node name="LogTitle" type="Label" parent="UILayer/LogPanel/LogContainer"]
+layout_mode = 2
+theme_override_colors/font_color = Color(1, 1, 0.8, 1)
+theme_override_font_sizes/font_size = 18
+text = "テキストログ"
+horizontal_alignment = 1
+
+[node name="LogText" type="RichTextLabel" parent="UILayer/LogPanel/LogContainer"]
+layout_mode = 2
+size_flags_vertical = 3
+theme_override_colors/default_color = Color(1, 1, 1, 1)
+theme_override_font_sizes/normal_font_size = 14
+bbcode_enabled = true
+fit_content = true
+
+[node name="CloseButton" type="Button" parent="UILayer/LogPanel/LogContainer"]
+layout_mode = 2
+text = "閉じる"

--- a/GodotProject/Scripts/systems/text_scene_manager.gd
+++ b/GodotProject/Scripts/systems/text_scene_manager.gd
@@ -1,0 +1,170 @@
+class_name TextSceneManager
+extends Node
+
+signal scene_finished
+signal choice_made(choice_index: int)
+
+# シーンデータ構造
+class SceneData:
+	var background_path: String = ""
+	var character_left_path: String = ""
+	var character_right_path: String = ""
+	var speaker_name: String = ""
+	var text: String = ""
+	var choices: Array[String] = []
+	var scene_id: String = ""
+	
+	func _init(p_scene_id: String = "", p_background: String = "", p_left: String = "", p_right: String = "", p_speaker: String = "", p_text: String = "", p_choices: Array[String] = []):
+		scene_id = p_scene_id
+		background_path = p_background
+		character_left_path = p_left
+		character_right_path = p_right
+		speaker_name = p_speaker
+		text = p_text
+		choices = p_choices.duplicate()
+
+# 現在の状態
+var current_scene_data: SceneData
+var text_scene: TextScene
+var is_waiting_for_input: bool = false
+
+# シナリオデータ（サンプル）
+var scenario_data: Array[SceneData] = []
+var current_scene_index: int = 0
+
+func _ready():
+	_load_sample_scenario()
+
+func _load_sample_scenario():
+	"""サンプルシナリオデータを読み込み"""
+	scenario_data = [
+		SceneData.new("scene_01", "", "", "", "ナレーション", "物語が始まります..."),
+		SceneData.new("scene_02", "", "", "", "ソウマ", "こんにちは！僕の名前はソウマです。"),
+		SceneData.new("scene_03", "", "", "", "ユズキ", "私はユズキ。よろしくお願いします。"),
+		SceneData.new("scene_04", "", "", "", "ソウマ", "学校に到着しました。今日はどうしましょうか？", ["教室に向かう", "屋上に行く", "図書館に行く"])
+	]
+
+func initialize_with_scene(scene: TextScene):
+	"""テキストシーンと連携を初期化"""
+	text_scene = scene
+	text_scene.text_finished.connect(_on_text_finished)
+	text_scene.choice_selected.connect(_on_choice_selected)
+	
+	# 最初のシーンを表示
+	current_scene_index = 0
+	if scenario_data.size() > 0:
+		_display_current_scene()
+
+func _display_current_scene():
+	"""現在のシーンを表示"""
+	if current_scene_index >= scenario_data.size():
+		_finish_scenario()
+		return
+	
+	current_scene_data = scenario_data[current_scene_index]
+	
+	# 背景設定
+	if not current_scene_data.background_path.is_empty():
+		text_scene.set_background(current_scene_data.background_path)
+	
+	# 立ち絵設定
+	text_scene.set_character_portrait("left", current_scene_data.character_left_path)
+	text_scene.set_character_portrait("right", current_scene_data.character_right_path)
+	
+	# テキスト表示
+	text_scene.show_text(current_scene_data.speaker_name, current_scene_data.text)
+	
+	is_waiting_for_input = true
+	print("シーン表示: %s" % current_scene_data.scene_id)
+
+func _on_text_finished():
+	"""テキスト表示完了時の処理"""
+	if not is_waiting_for_input:
+		return
+	
+	is_waiting_for_input = false
+	
+	# 選択肢がある場合
+	if current_scene_data.choices.size() > 0:
+		_show_choices()
+	else:
+		# 次のシーンへ進む
+		_advance_to_next_scene()
+
+func _show_choices():
+	"""選択肢を表示"""
+	print("選択肢表示: %s" % current_scene_data.choices)
+	# TODO: 選択肢UIの実装
+	# 現在はデバッグ用に最初の選択肢を自動選択
+	_on_choice_selected(0)
+
+func _on_choice_selected(choice_index: int):
+	"""選択肢選択時の処理"""
+	if choice_index < 0 or choice_index >= current_scene_data.choices.size():
+		print("不正な選択肢インデックス: %d" % choice_index)
+		return
+	
+	var selected_choice = current_scene_data.choices[choice_index]
+	print("選択肢選択: %s" % selected_choice)
+	
+	choice_made.emit(choice_index)
+	
+	# 選択に応じた次のシーンへ
+	_advance_to_next_scene()
+
+func _advance_to_next_scene():
+	"""次のシーンへ進む"""
+	current_scene_index += 1
+	_display_current_scene()
+
+func _finish_scenario():
+	"""シナリオ終了処理"""
+	print("シナリオ終了")
+	scene_finished.emit()
+	
+	# メインシーンに戻る（または他の処理）
+	await get_tree().create_timer(1.0).timeout
+	get_tree().change_scene_to_file("res://Scenes/Main.tscn")
+
+# 外部からのシーン制御API
+func load_scenario_from_file(file_path: String):
+	"""外部ファイルからシナリオを読み込み"""
+	# TODO: JSONやCSVからのシナリオ読み込み実装
+	print("シナリオファイル読み込み: %s" % file_path)
+
+func jump_to_scene(scene_id: String):
+	"""指定されたシーンIDにジャンプ"""
+	for i in range(scenario_data.size()):
+		if scenario_data[i].scene_id == scene_id:
+			current_scene_index = i
+			_display_current_scene()
+			return
+	
+	print("シーンIDが見つかりません: %s" % scene_id)
+
+func set_background(background_path: String):
+	"""現在のシーンの背景を変更"""
+	if text_scene:
+		text_scene.set_background(background_path)
+
+func set_character(position: String, character_path: String):
+	"""現在のシーンの立ち絵を変更"""
+	if text_scene:
+		text_scene.set_character_portrait(position, character_path)
+
+func show_message(speaker: String, message: String):
+	"""即座にメッセージを表示"""
+	if text_scene:
+		text_scene.show_text(speaker, message)
+
+func get_current_scene_id() -> String:
+	"""現在のシーンIDを取得"""
+	if current_scene_data:
+		return current_scene_data.scene_id
+	return ""
+
+func get_text_history() -> Array[Dictionary]:
+	"""テキスト履歴を取得"""
+	if text_scene:
+		return text_scene.get_log_history()
+	return []

--- a/GodotProject/Scripts/ui/dialogue_box.gd
+++ b/GodotProject/Scripts/ui/dialogue_box.gd
@@ -141,9 +141,33 @@ func start_typing_effect(text: String):
 	typing_tween.tween_callback(complete_current_line)
 
 func set_partial_text(full_text: String, char_count: int):
-	if char_count > full_text.length():
-		char_count = full_text.length()
-	content_label.text = full_text.substr(0, char_count)
+	# 安全な境界チェック
+	if full_text.is_empty():
+		content_label.text = ""
+		return
+	
+	var safe_char_count = max(0, min(char_count, full_text.length()))
+	content_label.text = _safe_substr(full_text, 0, safe_char_count)
+
+func _safe_substr(source: String, start: int, length: int) -> String:
+	"""安全なsubstr実装"""
+	if source.is_empty():
+		return ""
+	
+	if start < 0:
+		start = 0
+	
+	if start >= source.length():
+		return ""
+	
+	if length < 0:
+		return ""
+	
+	var end_pos = start + length
+	if end_pos > source.length():
+		end_pos = source.length()
+	
+	return source.substr(start, end_pos - start)
 
 func complete_current_line():
 	if typing_tween:

--- a/GodotProject/Scripts/ui/text_scene.gd
+++ b/GodotProject/Scripts/ui/text_scene.gd
@@ -1,0 +1,256 @@
+class_name TextScene
+extends Control
+
+signal text_finished
+signal choice_selected(choice_index: int)
+
+# ノード参照
+@onready var background: TextureRect = $BackgroundLayer/Background
+@onready var character_left: TextureRect = $CharacterLayer/CharacterLeft
+@onready var character_right: TextureRect = $CharacterLayer/CharacterRight
+@onready var text_window: Control = $UILayer/TextWindow
+@onready var name_label: Label = $UILayer/TextWindow/NameContainer/NameLabel
+@onready var text_label: RichTextLabel = $UILayer/TextWindow/TextContainer/TextLabel
+@onready var continue_indicator: Control = $UILayer/TextWindow/ContinueIndicator
+@onready var log_button: Button = $UILayer/LogButton
+@onready var log_panel: Control = $UILayer/LogPanel
+@onready var log_text: RichTextLabel = $UILayer/LogPanel/LogContainer/LogText
+@onready var log_close_button: Button = $UILayer/LogPanel/LogContainer/CloseButton
+
+# テキスト表示関連
+var current_text: String = ""
+var current_character_index: int = 0
+var text_speed: float = 0.05
+var is_text_animating: bool = false
+var text_tween: Tween
+
+# テキストログ
+var text_history: Array[Dictionary] = []
+var max_log_entries: int = 100
+
+# 立ち絵管理
+var character_portraits: Dictionary = {}
+
+# シーンマネージャー
+var scene_manager: TextSceneManager
+
+func _ready():
+	_setup_ui()
+	_connect_signals()
+	_setup_initial_state()
+	_initialize_scene_manager()
+
+func _initialize_scene_manager():
+	"""シーンマネージャーを初期化"""
+	scene_manager = TextSceneManager.new()
+	add_child(scene_manager)
+	scene_manager.initialize_with_scene(self)
+
+func _setup_ui():
+	# テキストウィンドウの設定
+	text_window.visible = true
+	text_label.bbcode_enabled = true
+	text_label.fit_content = true
+	
+	# 継続インジケーターの設定
+	continue_indicator.visible = false
+	
+	# ログパネルの設定
+	log_panel.visible = false
+	log_text.bbcode_enabled = true
+
+func _connect_signals():
+	# ログボタン
+	log_button.pressed.connect(_on_log_button_pressed)
+	log_close_button.pressed.connect(_on_log_close_button_pressed)
+	
+	# テキスト進行（クリック・キー入力）
+	text_window.gui_input.connect(_on_text_window_input)
+
+func _setup_initial_state():
+	# 背景をクリア
+	background.texture = null
+	background.color = Color.BLACK
+	
+	# 立ち絵をクリア
+	character_left.texture = null
+	character_left.visible = false
+	character_right.texture = null
+	character_right.visible = false
+	
+	# テキストをクリア
+	clear_text()
+
+func _unhandled_input(event):
+	if event.is_action_pressed("ui_accept") or event is InputEventMouseButton:
+		if event is InputEventMouseButton and event.pressed and event.button_index == MOUSE_BUTTON_LEFT:
+			_advance_text()
+	elif event.is_action_pressed("ui_cancel"):
+		if log_panel.visible:
+			_close_log()
+
+func _on_text_window_input(event):
+	if event is InputEventMouseButton and event.pressed and event.button_index == MOUSE_BUTTON_LEFT:
+		_advance_text()
+
+func _advance_text():
+	if is_text_animating:
+		# アニメーション中なら即座に完了
+		_complete_text_animation()
+	elif continue_indicator.visible:
+		# テキスト表示完了後なら次へ
+		text_finished.emit()
+
+func set_background(texture_path: String):
+	"""背景CGを設定"""
+	if texture_path.is_empty():
+		background.texture = null
+		background.color = Color.BLACK
+		return
+	
+	var texture = load(texture_path) as Texture2D
+	if texture:
+		background.texture = texture
+		background.color = Color.WHITE
+		print("背景を設定: %s" % texture_path)
+	else:
+		print("背景の読み込みに失敗: %s" % texture_path)
+
+func set_character_portrait(position: String, texture_path: String):
+	"""立ち絵を設定 (position: "left" or "right")"""
+	var character_node: TextureRect
+	
+	match position.to_lower():
+		"left":
+			character_node = character_left
+		"right":
+			character_node = character_right
+		_:
+			print("不正な立ち絵位置: %s" % position)
+			return
+	
+	if texture_path.is_empty():
+		character_node.texture = null
+		character_node.visible = false
+		return
+	
+	var texture = load(texture_path) as Texture2D
+	if texture:
+		character_node.texture = texture
+		character_node.visible = true
+		print("立ち絵を設定 (%s): %s" % [position, texture_path])
+	else:
+		print("立ち絵の読み込みに失敗 (%s): %s" % [position, texture_path])
+
+func show_text(speaker_name: String, text: String):
+	"""テキストを表示"""
+	# 名前ラベルの設定
+	if speaker_name.is_empty():
+		name_label.text = ""
+		name_label.visible = false
+	else:
+		name_label.text = speaker_name
+		name_label.visible = true
+	
+	# テキストログに追加
+	_add_to_log(speaker_name, text)
+	
+	# テキストアニメーション開始
+	current_text = text
+	current_character_index = 0
+	is_text_animating = true
+	continue_indicator.visible = false
+	
+	_start_text_animation()
+
+func _start_text_animation():
+	"""テキストのタイピングアニメーション開始"""
+	text_label.text = ""
+	
+	if text_tween:
+		text_tween.kill()
+	
+	text_tween = create_tween()
+	text_tween.tween_method(_update_text_display, 0, current_text.length(), current_text.length() * text_speed)
+	text_tween.tween_callback(_on_text_animation_complete)
+
+func _update_text_display(char_count: int):
+	"""テキスト表示の更新"""
+	var displayed_text = current_text.substr(0, char_count)
+	text_label.text = displayed_text
+
+func _complete_text_animation():
+	"""テキストアニメーションを即座に完了"""
+	if text_tween:
+		text_tween.kill()
+	
+	text_label.text = current_text
+	_on_text_animation_complete()
+
+func _on_text_animation_complete():
+	"""テキストアニメーション完了"""
+	is_text_animating = false
+	continue_indicator.visible = true
+
+func clear_text():
+	"""テキスト表示をクリア"""
+	name_label.text = ""
+	name_label.visible = false
+	text_label.text = ""
+	continue_indicator.visible = false
+	
+	if text_tween:
+		text_tween.kill()
+	
+	is_text_animating = false
+
+func _add_to_log(speaker_name: String, text: String):
+	"""テキストログに追加"""
+	var log_entry = {
+		"speaker": speaker_name,
+		"text": text,
+		"timestamp": Time.get_datetime_string_from_system()
+	}
+	
+	text_history.append(log_entry)
+	
+	# ログサイズ制限
+	if text_history.size() > max_log_entries:
+		text_history.pop_front()
+
+func _on_log_button_pressed():
+	"""ログボタン押下"""
+	_show_log()
+
+func _show_log():
+	"""ログパネルを表示"""
+	_update_log_display()
+	log_panel.visible = true
+
+func _update_log_display():
+	"""ログ表示を更新"""
+	var log_content = ""
+	
+	for entry in text_history:
+		if not entry.speaker.is_empty():
+			log_content += "[color=yellow]%s[/color]\n" % entry.speaker
+		log_content += "%s\n\n" % entry.text
+	
+	log_text.text = log_content
+
+func _on_log_close_button_pressed():
+	"""ログ閉じるボタン押下"""
+	_close_log()
+
+func _close_log():
+	"""ログパネルを閉じる"""
+	log_panel.visible = false
+
+func get_log_history() -> Array[Dictionary]:
+	"""ログ履歴を取得"""
+	return text_history.duplicate()
+
+func clear_log():
+	"""ログをクリア"""
+	text_history.clear()
+	_update_log_display()

--- a/GodotProject/Scripts/ui/title_screen.gd
+++ b/GodotProject/Scripts/ui/title_screen.gd
@@ -144,7 +144,7 @@ func _transition_to_game():
 	tween.tween_callback(_change_to_game_scene).set_delay(0.5)
 
 func _change_to_game_scene():
-	get_tree().change_scene_to_file("res://Scenes/Main.tscn")
+	get_tree().change_scene_to_file("res://Scenes/TextScene.tscn")
 
 func _quit_game():
 	# 終了アニメーション


### PR DESCRIPTION
## 概要
issue#23の実装完了。タイトル画面でゲームスタートボタンを押下すると、テキストシーンに遷移し、背景CG、立ち絵（最大2枚）を指定して表示できるシステムを実装しました。

## 実装内容

### ✅ 新規作成ファイル
- **`TextScene.tscn`**: テキスト表示専用シーン
- **`text_scene.gd`**: テキストシーン制御システム  
- **`text_scene_manager.gd`**: シーン統合管理システム

### ✅ 修正ファイル
- **`title_screen.gd`**: 新規ゲーム時の遷移先をTextSceneに変更

## 📋 実装機能詳細

### テキストシーンシステム
- [x] **背景CG表示**: `set_background()`で動的背景切り替え
- [x] **立ち絵表示**: 左右2枚同時表示対応（`set_character_portrait()`）
- [x] **テキストウィンドウ**: タイピングエフェクト付き表示
- [x] **テキストログ**: 履歴管理とログパネル表示
- [x] **シーン管理**: 構造化されたシナリオデータ管理

### UI/UX機能
- [x] クリック・キー入力による進行制御
- [x] 継続インジケーター表示（「▼クリック」）
- [x] ログボタンによるテキスト履歴表示
- [x] スタイル付きパネルとレイアウト

### システム設計
- [x] Godot Scene + Node + Signal パターン
- [x] リソース分離による軽量化設計
- [x] TextSceneManagerによる統合制御
- [x] サンプルシナリオによる動作デモ

## 🎮 動作フロー

1. **タイトル画面**: 「新規ゲーム」ボタンクリック
2. **自動遷移**: TextScene.tscnに切り替え
3. **シナリオ開始**: サンプルテキストでデモ実行
4. **進行制御**: クリック/キーで次のテキストへ
5. **ログ機能**: ログボタンで履歴表示

## 🏗️ 技術仕様

- **エンジン**: Godot 4.x
- **言語**: GDScript（型ヒント付き）
- **UI**: Control + RichTextLabel
- **アニメーション**: Tweeシステム
- **設計**: Scene/Node/Signal パターン

## 🧪 テスト方法

1. Godot Editorで`MainMenu.tscn`を実行
2. 「新規ゲーム」ボタンをクリック
3. テキストシーンが表示されることを確認
4. サンプルシナリオが正常に進行することを確認
5. ログボタンでテキスト履歴が表示されることを確認

## 📝 今後の拡張予定

- 選択肢システムの実装
- 画像リソースとの連携
- セーブ・ロード機能との統合
- アニメーション効果の追加

---

@coderabbitai このPRをレビューしてください。特に以下の点を確認お願いします：
- GDScriptの型安全性とコーディング規約遵守
- Godot Scene/Node/Signal パターンの適切な実装
- エラーハンドリングとNull安全性
- パフォーマンスと保守性の観点

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * ビジュアルノベル風のテキスト表示システムを追加しました。背景画像、キャラクターポートレート、話者名、アニメーション付きテキスト表示、テキストログ機能、選択肢表示に対応しています。
  * テキストログの閲覧や、シーンごとの進行管理が可能になりました。
* **変更**
  * タイトル画面からゲーム開始時の遷移先が新しいテキストシーンに変更されました。
* **修正**
  * テキスト表示の部分文字列抽出処理を安全に行うよう改善しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->